### PR TITLE
HOME-206 - Persist influxdb data from container to host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run-dev:
 
 .PHONY: run-prod
 run-prod:
-	docker run -it -d -p 3222:3222 oszura/smarthome-server-prod /bin/bash
+	docker run -it -d -p 3222:3222 -v /var/lib/influxdb-backup:/var/lib/influxdb oszura/smarthome-server-prod /bin/bash
 
 .PHONY: version
 version:


### PR DESCRIPTION
**Business justification:** https://trello.com/c/abZaWfB0/206-home-persist-influxdb-data-from-container-to-host

**Description:** By default all data are lost from container when container is closed. Mounting a volume to the host machine persist data even though container is closed.