### PR TITLE
HOME-209 - Don't setup a new database in PROD image

### DIFF
--- a/entrypoint-prod.sh
+++ b/entrypoint-prod.sh
@@ -1,4 +1,3 @@
 /root/scripts/start_services.sh && \
 sleep 10 && \
-/root/scripts/mock_data.sh && \
 /root/scripts/start_smarthome.sh


### PR DESCRIPTION
**Business justification:** https://trello.com/c/kvGTAmmF/209-home-209-dont-setup-a-new-database-in-prod-image

**Description:** When PROD was re-deployed and influxdb database did exist already, the influxdb init script was causing an error as the database did exist. There's no need to re-set the database on every deployment.