### PR TITLE
HOME-224 - Replace sleep with while in smarthome-server scripts where…

### DIFF
--- a/start_services.sh
+++ b/start_services.sh
@@ -1,3 +1,4 @@
+echo "Starting services ..."
 mongod --repair > /dev/null 2>&1 &&
 mongod > /dev/null 2>&1 &
 influxd > /dev/null 2>&1 &
@@ -6,3 +7,5 @@ while ! curl -sl -I http://localhost:8086/ping
 do
   sleep 1
 done
+
+echo "Influxdb is running"

--- a/start_services.shy
+++ b/start_services.shy
@@ -1,8 +1,0 @@
-echo "Starting services..."
-mongod --repair > /dev/null 2>&1 &&
-mongod > /dev/null 2>&1 &
-influxd > /dev/null 2>&1 &
-
-while ! curl -sl -I http://localhost:8086/ping ; do
-  sleep 1
-done

--- a/start_services.shy
+++ b/start_services.shy
@@ -1,8 +1,8 @@
+echo "Starting services..."
 mongod --repair > /dev/null 2>&1 &&
 mongod > /dev/null 2>&1 &
 influxd > /dev/null 2>&1 &
 
-while ! curl -sl -I http://localhost:8086/ping 
-do
+while ! curl -sl -I http://localhost:8086/ping ; do
   sleep 1
 done


### PR DESCRIPTION
… possible

**Bussiness justification:** https://trello.com/c/zIk5hLSa/224-home-224-replace-sleep-with-while-in-smarthome-server-scripts-where-possible

**Description:** Sometimes curl'ing to non existing influx db was causing exit with code 1. We want to make sure influxdb is up and running before curling with database creation query.